### PR TITLE
Added routing for Home Profile and Explore components

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,24 +1,20 @@
 import React from "react";
-import MDEditor from '@uiw/react-md-editor';
-import rehypeSanitize from "rehype-sanitize";
 import "./App.css";
-import {Navbar} from "./components/navbar";
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import Home from "./components/Home";
+import Profile from "./components/Profile";
+import Explore from "./components/Explore";
 
 export default function App() {
-  const [value, setValue] = React.useState(`👋 **Hello!** You can edit the .md code here`);
-
   return (
     <>
-      <Navbar />
-      <div className="m-10">
-      <MDEditor
-        value={value}
-        onChange={setValue}
-        previewOptions={{
-          rehypePlugins: [[rehypeSanitize]],
-        }}
-      />
-      </div>
+      <Router>
+        <Routes>
+          <Route path="/" index element={<Home />} />
+          <Route path="/dashboard" element={<Profile />} />
+          <Route path="/community" element={<Explore />} />
+        </Routes>
+      </Router>
     </>
   );
 }

--- a/client/src/components/Explore.js
+++ b/client/src/components/Explore.js
@@ -1,0 +1,13 @@
+import React from "react";
+
+const Explore = () => {
+  return (
+    <>
+      <div className="text-white">
+        Explore page
+      </div>
+    </>
+  );
+};
+
+export default Explore;

--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -1,0 +1,26 @@
+import React from "react";
+import { Navbar } from "./navbar";
+import MDEditor from "@uiw/react-md-editor";
+import rehypeSanitize from "rehype-sanitize";
+
+const Home = () => {
+  const [value, setValue] = React.useState(
+    `👋 **Hello!** You can edit the .md code here`
+  );
+  return (
+    <>
+      <Navbar />
+      <div className="m-10">
+        <MDEditor
+          value={value}
+          onChange={setValue}
+          previewOptions={{
+            rehypePlugins: [[rehypeSanitize]],
+          }}
+        />
+      </div>
+    </>
+  );
+};
+
+export default Home;

--- a/client/src/components/Profile.js
+++ b/client/src/components/Profile.js
@@ -1,0 +1,13 @@
+import React from "react";
+
+const Profile = () => {
+  return (
+    <>
+      <div className="text-white">
+        Profile page
+      </div>
+    </>
+  );
+};
+
+export default Profile;


### PR DESCRIPTION
Feat: #3 
Added routing using react-router-dom in the frontend

The "/" path is the route for main page
![image](https://github.com/Harshal141/ResumeWorded/assets/89152237/ab6b0e68-6e53-4e4f-8fb5-a6860404de11)

<hr>

The "/dashboard" is the route for Profile page

![image](https://github.com/Harshal141/ResumeWorded/assets/89152237/1ff3c452-984b-4e0d-ab90-16c538e49b7f)

<hr>

The "/community" route is for Explore page

![image](https://github.com/Harshal141/ResumeWorded/assets/89152237/59cabb2b-5f23-420d-bbff-c9feb826aa69)
